### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -2,19 +2,19 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-ButtonGroup    KEYWORD1
+ButtonGroup	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-registerPin    KEYWORD2
-unregisterPin  KEYWORD2
-readAllPins    KEYWORD2
-readPin        KEYWORD2
+registerPin	KEYWORD2
+unregisterPin	KEYWORD2
+readAllPins	KEYWORD2
+readPin	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-MAX_PINS       LITERAL1
+MAX_PINS	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords